### PR TITLE
忽略搜索源

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ venv/*
 
 src/**/__pycache__/
 src/**/.DS_Store
-src/scrapers/dandanplay.py
 config/danmaku
 config/image
 
@@ -18,13 +17,5 @@ src/security_core.py
 src/rate_limiter.py
 .vscode/settings.json
 generator_config.ini
-src/scrapers/bilibili.py
-src/scrapers/gamer.py
-src/scrapers/hanjutv.py
-src/scrapers/iqiyi.py
-src/scrapers/le.py
-src/scrapers/mgtv.py
-src/scrapers/renren.py
-src/scrapers/sohu.py
-src/scrapers/tencent.py
-src/scrapers/youku.py
+src/scrapers
+!src/scrapers/base.py

--- a/web/src/pages/home/components/Logs.jsx
+++ b/web/src/pages/home/components/Logs.jsx
@@ -70,7 +70,7 @@ export const Logs = () => {
   }, [])
 
   const exportLogs = () => {
-    const blob = new Blob([logs.join('\r\n')], { type: 'text/plain' })
+    const blob = new Blob([logs.slice().reverse().join('\r\n')], { type: 'text/plain' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -20,6 +20,16 @@ export default defineConfig({
         target: 'http://localhost:7768',
         changeOrigin: true,
         secure: false,
+      },
+      '/static': {
+        target: 'http://localhost:7768',
+        changeOrigin: true,
+        secure: false,
+      },
+      '/openapi.json': {
+        target: 'http://localhost:7768',
+        changeOrigin: true,
+        secure: false,
       }
     }
   },


### PR DESCRIPTION
代理 openapi.json 和 data 路径，指向本地后端服务器

反转导出的日志文件内容顺序